### PR TITLE
fix: move svelte to devDependencies, update package.json exports

### DIFF
--- a/.changeset/fast-knives-chew.md
+++ b/.changeset/fast-knives-chew.md
@@ -1,0 +1,5 @@
+---
+"svelte-contextify": patch
+---
+
+fix: move svelte to devDependencies, update package.json exports

--- a/package.json
+++ b/package.json
@@ -29,12 +29,9 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"import": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
 		}
-	},
-	"dependencies": {
-		"svelte": "5.0.0-next.178"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.3",
@@ -42,11 +39,12 @@
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"@testing-library/svelte": "^5.2.0",
 		"happy-dom": "^14.12.3",
+		"svelte": "^5.0.0-next.178",
 		"typescript": "^5.5.3",
 		"vitest": "^2.0.1"
 	},
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": "^4.0.0 || ^5.0.0-next.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      svelte:
-        specifier: 5.0.0-next.178
-        version: 5.0.0-next.178
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.8.3
@@ -27,6 +23,9 @@ importers:
       happy-dom:
         specifier: ^14.12.3
         version: 14.12.3
+      svelte:
+        specifier: ^5.0.0-next.178
+        version: 5.0.0-next.178
       typescript:
         specifier: ^5.5.3
         version: 5.5.3


### PR DESCRIPTION
Publint currently reports an issue with the sorting of the package.json exports map: https://publint.dev/svelte-contextify@1.0.3

Additionally, svelte v5 is marked as a dependency, while the peerDep range has svelte v4. peerDeps should be installed as a devDep instead of a dep, and I've updated the peerDep range to include svelte v4 and v5.